### PR TITLE
fix(parser): Allow dash inside varnames

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -216,7 +216,7 @@ fn parse_async_class(data: &str) -> Option<(msg::AsyncClass, &str)> {
 }
 
 fn parse_varname(data: &str) -> Option<(msg::VarName, &str)> {
-    static_regex!(RE = r"^[a-zA-Z_][a-zA-Z0-9_]*");
+    static_regex!(RE = r"^[a-zA-Z_][a-zA-Z0-9_-]*");
     if let Some((_, count)) = RE.find(data) {
         Some(parse(data, count))
     } else {


### PR DESCRIPTION
GDB may return varnames containing dashes. For example if a new
breakpoint is created, gdb may return something like this:
`=breakpoint-created,bkpt={number="1",type="catchpoint",disp="keep",enabled="y",catch-type="fork",thread-groups=["i1"],times="0"}\n`
Previously rust-gdb returned a `ParseError` because the varname regex
did not allow `-`.